### PR TITLE
Update decn.c

### DIFF
--- a/src/decn/decn.c
+++ b/src/decn/decn.c
@@ -1591,7 +1591,7 @@ void to_radian_decn(void) {
 void pi_decn(void) {
 	set_dec80_zero(&BDecn);
 	copy_decn(&AccDecn, &DECN_PI);
-	mult_decn();
+	// mult_decn();  
 }
 
 static void set_str_error(void){


### PR DESCRIPTION
A call to mult_decn is not needed and prevents PI from being loaded into the X register.